### PR TITLE
Add global error handling to Express backend

### DIFF
--- a/backend/routes/blocos.js
+++ b/backend/routes/blocos.js
@@ -4,18 +4,17 @@ const router = express.Router();
 const db = require('../db');
 
 // GET /api/blocos - Buscar todos os blocos
-router.get('/', async (req, res) => {
+router.get('/', async (req, res, next) => {
     try {
         const { rows } = await db.query('SELECT * FROM blocos ORDER BY nome ASC');
         res.json(rows);
     } catch (err) {
-        console.error(err.message);
-        res.status(500).json({ error: 'Erro no servidor' });
+        next(err);
     }
 });
 
 // POST /api/blocos - Criar novo bloco
-router.post('/', async (req, res) => {
+router.post('/', async (req, res, next) => {
     try {
         const { nome, descricao } = req.body;
 
@@ -24,12 +23,11 @@ router.post('/', async (req, res) => {
             VALUES ($1, $2, NOW())
             RETURNING *
         `;
-        
+
         const { rows } = await db.query(query, [nome, descricao]);
         res.status(201).json(rows[0]);
     } catch (err) {
-        console.error(err.message);
-        res.status(500).json({ error: 'Erro ao criar bloco' });
+        next(err);
     }
 });
 

--- a/backend/routes/contatos.js
+++ b/backend/routes/contatos.js
@@ -4,35 +4,33 @@ const router = express.Router();
 const db = require('../db');
 
 // GET /api/contatos - Buscar todos os contatos
-router.get('/', async (req, res) => {
+router.get('/', async (req, res, next) => {
     try {
         const { rows } = await db.query('SELECT * FROM contatos ORDER BY nome ASC');
         res.json(rows);
     } catch (err) {
-        console.error(err.message);
-        res.status(500).json({ error: 'Erro no servidor' });
+        next(err);
     }
 });
 
 // GET /api/contatos/:id - Buscar contato específico
-router.get('/:id', async (req, res) => {
+router.get('/:id', async (req, res, next) => {
     try {
         const { id } = req.params;
         const { rows } = await db.query('SELECT * FROM contatos WHERE id = $1', [id]);
-        
+
         if (rows.length === 0) {
             return res.status(404).json({ error: 'Contato não encontrado' });
         }
-        
+
         res.json(rows[0]);
     } catch (err) {
-        console.error(err.message);
-        res.status(500).json({ error: 'Erro no servidor' });
+        next(err);
     }
 });
 
 // POST /api/contatos - Criar novo contato
-router.post('/', async (req, res) => {
+router.post('/', async (req, res, next) => {
     try {
         const {
             natureza_contato, nome, sigla, cpf, rg, data_nascimento,
@@ -48,7 +46,7 @@ router.post('/', async (req, res) => {
             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NOW())
             RETURNING *
         `;
-        
+
         const values = [
             natureza_contato, nome, sigla, cpf, rg, data_nascimento,
             email, telefone_fixo, telefone_celular, cep, endereco,
@@ -58,13 +56,12 @@ router.post('/', async (req, res) => {
         const { rows } = await db.query(query, values);
         res.status(201).json(rows[0]);
     } catch (err) {
-        console.error(err.message);
-        res.status(500).json({ error: 'Erro ao criar contato' });
+        next(err);
     }
 });
 
 // PUT /api/contatos/:id - Atualizar contato
-router.put('/:id', async (req, res) => {
+router.put('/:id', async (req, res, next) => {
     try {
         const { id } = req.params;
         const {
@@ -74,7 +71,7 @@ router.put('/:id', async (req, res) => {
         } = req.body;
 
         const query = `
-            UPDATE contatos SET 
+            UPDATE contatos SET
                 natureza_contato = $1, nome = $2, sigla = $3, cpf = $4, rg = $5,
                 data_nascimento = $6, email = $7, telefone_fixo = $8, telefone_celular = $9,
                 cep = $10, endereco = $11, bairro = $12, cidade = $13, uf = $14,
@@ -82,7 +79,7 @@ router.put('/:id', async (req, res) => {
             WHERE id = $15
             RETURNING *
         `;
-        
+
         const values = [
             natureza_contato, nome, sigla, cpf, rg, data_nascimento,
             email, telefone_fixo, telefone_celular, cep, endereco,
@@ -90,32 +87,30 @@ router.put('/:id', async (req, res) => {
         ];
 
         const { rows } = await db.query(query, values);
-        
+
         if (rows.length === 0) {
             return res.status(404).json({ error: 'Contato não encontrado' });
         }
-        
+
         res.json(rows[0]);
     } catch (err) {
-        console.error(err.message);
-        res.status(500).json({ error: 'Erro ao atualizar contato' });
+        next(err);
     }
 });
 
 // DELETE /api/contatos/:id - Excluir contato
-router.delete('/:id', async (req, res) => {
+router.delete('/:id', async (req, res, next) => {
     try {
         const { id } = req.params;
         const { rows } = await db.query('DELETE FROM contatos WHERE id = $1 RETURNING *', [id]);
-        
+
         if (rows.length === 0) {
             return res.status(404).json({ error: 'Contato não encontrado' });
         }
-        
+
         res.json({ message: 'Contato excluído com sucesso' });
     } catch (err) {
-        console.error(err.message);
-        res.status(500).json({ error: 'Erro ao excluir contato' });
+        next(err);
     }
 });
 

--- a/backend/routes/documentos.js
+++ b/backend/routes/documentos.js
@@ -4,46 +4,44 @@ const router = express.Router();
 const db = require('../db');
 
 // GET /api/documentos - Buscar todos os documentos
-router.get('/', async (req, res) => {
+router.get('/', async (req, res, next) => {
     try {
         const { processo_id } = req.query;
         let query = 'SELECT * FROM documentos';
         const values = [];
-        
+
         if (processo_id) {
             query += ' WHERE processo_id = $1';
             values.push(processo_id);
         }
-        
+
         query += ' ORDER BY criado_em DESC';
-        
+
         const { rows } = await db.query(query, values);
         res.json(rows);
     } catch (err) {
-        console.error(err.message);
-        res.status(500).json({ error: 'Erro no servidor' });
+        next(err);
     }
 });
 
 // GET /api/documentos/:id - Buscar documento específico
-router.get('/:id', async (req, res) => {
+router.get('/:id', async (req, res, next) => {
     try {
         const { id } = req.params;
         const { rows } = await db.query('SELECT * FROM documentos WHERE id = $1', [id]);
-        
+
         if (rows.length === 0) {
             return res.status(404).json({ error: 'Documento não encontrado' });
         }
-        
+
         res.json(rows[0]);
     } catch (err) {
-        console.error(err.message);
-        res.status(500).json({ error: 'Erro no servidor' });
+        next(err);
     }
 });
 
 // POST /api/documentos - Criar novo documento
-router.post('/', async (req, res) => {
+router.post('/', async (req, res, next) => {
     try {
         const {
             processo_id,
@@ -56,12 +54,12 @@ router.post('/', async (req, res) => {
 
         const query = `
             INSERT INTO documentos (
-                processo_id, titulo, tipo_documento, conteudo, 
+                processo_id, titulo, tipo_documento, conteudo,
                 arquivo_path, nivel_acesso, criado_em
             ) VALUES ($1, $2, $3, $4, $5, $6, NOW())
             RETURNING *
         `;
-        
+
         const values = [
             processo_id, titulo, tipo_documento, conteudo,
             arquivo_path, nivel_acesso
@@ -70,13 +68,12 @@ router.post('/', async (req, res) => {
         const { rows } = await db.query(query, values);
         res.status(201).json(rows[0]);
     } catch (err) {
-        console.error(err.message);
-        res.status(500).json({ error: 'Erro ao criar documento' });
+        next(err);
     }
 });
 
 // PUT /api/documentos/:id - Atualizar documento
-router.put('/:id', async (req, res) => {
+router.put('/:id', async (req, res, next) => {
     try {
         const { id } = req.params;
         const {
@@ -88,44 +85,42 @@ router.put('/:id', async (req, res) => {
         } = req.body;
 
         const query = `
-            UPDATE documentos SET 
+            UPDATE documentos SET
                 titulo = $1, tipo_documento = $2, conteudo = $3,
                 arquivo_path = $4, nivel_acesso = $5, atualizado_em = NOW()
             WHERE id = $6
             RETURNING *
         `;
-        
+
         const values = [
             titulo, tipo_documento, conteudo, arquivo_path, nivel_acesso, id
         ];
 
         const { rows } = await db.query(query, values);
-        
+
         if (rows.length === 0) {
             return res.status(404).json({ error: 'Documento não encontrado' });
         }
-        
+
         res.json(rows[0]);
     } catch (err) {
-        console.error(err.message);
-        res.status(500).json({ error: 'Erro ao atualizar documento' });
+        next(err);
     }
 });
 
 // DELETE /api/documentos/:id - Excluir documento
-router.delete('/:id', async (req, res) => {
+router.delete('/:id', async (req, res, next) => {
     try {
         const { id } = req.params;
         const { rows } = await db.query('DELETE FROM documentos WHERE id = $1 RETURNING *', [id]);
-        
+
         if (rows.length === 0) {
             return res.status(404).json({ error: 'Documento não encontrado' });
         }
-        
+
         res.json({ message: 'Documento excluído com sucesso' });
     } catch (err) {
-        console.error(err.message);
-        res.status(500).json({ error: 'Erro ao excluir documento' });
+        next(err);
     }
 });
 

--- a/backend/routes/estatisticas.js
+++ b/backend/routes/estatisticas.js
@@ -4,7 +4,7 @@ const router = express.Router();
 const db = require('../db');
 
 // GET /api/estatisticas/processos-por-tipo - Estatísticas de processos por tipo
-router.get('/processos-por-tipo', async (req, res) => {
+router.get('/processos-por-tipo', async (req, res, next) => {
     try {
         const { rows } = await db.query(`
             SELECT tipo_processo, COUNT(*) as quantidade
@@ -15,16 +15,15 @@ router.get('/processos-por-tipo', async (req, res) => {
         `);
         res.json(rows);
     } catch (err) {
-        console.error(err.message);
-        res.status(500).json({ error: 'Erro no servidor' });
+        next(err);
     }
 });
 
 // GET /api/estatisticas/tempo-medio - Tempo médio de tramitação
-router.get('/tempo-medio', async (req, res) => {
+router.get('/tempo-medio', async (req, res, next) => {
     try {
         const { rows } = await db.query(`
-            SELECT 
+            SELECT
                 DATE_TRUNC('month', criado_em) as mes,
                 AVG(EXTRACT(DAYS FROM (COALESCE(atualizado_em, NOW()) - criado_em))) as tempo_medio_dias
             FROM processos
@@ -34,8 +33,7 @@ router.get('/tempo-medio', async (req, res) => {
         `);
         res.json(rows);
     } catch (err) {
-        console.error(err.message);
-        res.status(500).json({ error: 'Erro no servidor' });
+        next(err);
     }
 });
 

--- a/backend/routes/pesquisa.js
+++ b/backend/routes/pesquisa.js
@@ -4,10 +4,10 @@ const router = express.Router();
 const db = require('../db');
 
 // GET /api/pesquisa - Pesquisar processos
-router.get('/', async (req, res) => {
+router.get('/', async (req, res, next) => {
     try {
         const { q, tipo, data_inicio, data_fim } = req.query;
-        
+
         let query = 'SELECT * FROM processos WHERE 1=1';
         const values = [];
         let paramCount = 0;
@@ -41,8 +41,7 @@ router.get('/', async (req, res) => {
         const { rows } = await db.query(query, values);
         res.json(rows);
     } catch (err) {
-        console.error(err.message);
-        res.status(500).json({ error: 'Erro no servidor' });
+        next(err);
     }
 });
 

--- a/backend/routes/processos.js
+++ b/backend/routes/processos.js
@@ -4,35 +4,33 @@ const router = express.Router();
 const db = require('../db');
 
 // GET /api/processos - Buscar todos os processos
-router.get('/', async (req, res) => {
+router.get('/', async (req, res, next) => {
     try {
         const { rows } = await db.query('SELECT * FROM processos ORDER BY criado_em DESC');
         res.json(rows);
     } catch (err) {
-        console.error(err.message);
-        res.status(500).json({ error: 'Erro no servidor' });
+        next(err);
     }
 });
 
 // GET /api/processos/:id - Buscar processo específico
-router.get('/:id', async (req, res) => {
+router.get('/:id', async (req, res, next) => {
     try {
         const { id } = req.params;
         const { rows } = await db.query('SELECT * FROM processos WHERE id = $1', [id]);
-        
+
         if (rows.length === 0) {
             return res.status(404).json({ error: 'Processo não encontrado' });
         }
-        
+
         res.json(rows[0]);
     } catch (err) {
-        console.error(err.message);
-        res.status(500).json({ error: 'Erro no servidor' });
+        next(err);
     }
 });
 
 // POST /api/processos - Criar novo processo
-router.post('/', async (req, res) => {
+router.post('/', async (req, res, next) => {
     try {
         const {
             numero_processo,
@@ -49,13 +47,13 @@ router.post('/', async (req, res) => {
 
         const query = `
             INSERT INTO processos (
-                numero_processo, tipo_processo, especificacao, interessado, 
-                observacoes, nivel_acesso, tipo, protocolo_tipo, 
+                numero_processo, tipo_processo, especificacao, interessado,
+                observacoes, nivel_acesso, tipo, protocolo_tipo,
                 protocolo_numero_manual, protocolo_data, criado_em
             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
             RETURNING *
         `;
-        
+
         const values = [
             numero_processo, tipo_processo, especificacao, interessado,
             observacoes, nivel_acesso, tipo, protocolo_tipo,
@@ -65,13 +63,12 @@ router.post('/', async (req, res) => {
         const { rows } = await db.query(query, values);
         res.status(201).json(rows[0]);
     } catch (err) {
-        console.error(err.message);
-        res.status(500).json({ error: 'Erro ao criar processo' });
+        next(err);
     }
 });
 
 // PUT /api/processos/:id - Atualizar processo
-router.put('/:id', async (req, res) => {
+router.put('/:id', async (req, res, next) => {
     try {
         const { id } = req.params;
         const {
@@ -85,46 +82,44 @@ router.put('/:id', async (req, res) => {
         } = req.body;
 
         const query = `
-            UPDATE processos SET 
+            UPDATE processos SET
                 numero_processo = $1, tipo_processo = $2, especificacao = $3,
                 interessado = $4, observacoes = $5, nivel_acesso = $6, tipo = $7,
                 atualizado_em = NOW()
             WHERE id = $8
             RETURNING *
         `;
-        
+
         const values = [
             numero_processo, tipo_processo, especificacao, interessado,
             observacoes, nivel_acesso, tipo, id
         ];
 
         const { rows } = await db.query(query, values);
-        
+
         if (rows.length === 0) {
             return res.status(404).json({ error: 'Processo não encontrado' });
         }
-        
+
         res.json(rows[0]);
     } catch (err) {
-        console.error(err.message);
-        res.status(500).json({ error: 'Erro ao atualizar processo' });
+        next(err);
     }
 });
 
 // DELETE /api/processos/:id - Excluir processo
-router.delete('/:id', async (req, res) => {
+router.delete('/:id', async (req, res, next) => {
     try {
         const { id } = req.params;
         const { rows } = await db.query('DELETE FROM processos WHERE id = $1 RETURNING *', [id]);
-        
+
         if (rows.length === 0) {
             return res.status(404).json({ error: 'Processo não encontrado' });
         }
-        
+
         res.json({ message: 'Processo excluído com sucesso' });
     } catch (err) {
-        console.error(err.message);
-        res.status(500).json({ error: 'Erro ao excluir processo' });
+        next(err);
     }
 });
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -33,7 +33,16 @@ app.get('/', (req, res) => {
     res.send('API do SDI está no ar!');
 });
 
-// 7. Iniciar o servidor
+// 7. Middleware para rota não encontrada
+app.use((req, res) => res.status(404).json({ error: 'Rota não encontrada' }));
+
+// 8. Middleware de tratamento de erros
+app.use((err, req, res, next) => {
+    console.error(err);
+    res.status(500).json({ error: 'Erro interno' });
+});
+
+// 9. Iniciar o servidor
 app.listen(PORT, () => {
     console.log(`Servidor rodando com sucesso na porta ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- add 404 and global error-handling middlewares in the server
- streamline route handlers to delegate errors with `next(err)`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e59595388326aaa52a4518a5306e