### PR TITLE
feat(frontend): make API base URL configurable

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=/api

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -10,3 +10,17 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Configuração da API
+
+Defina o endereço base da API através da variável de ambiente `VITE_API_BASE_URL` no arquivo `.env`.
+
+```bash
+# Ambiente de desenvolvimento
+VITE_API_BASE_URL=/api
+
+# Ambiente de produção
+VITE_API_BASE_URL=https://seu-dominio.com/api
+```
+
+Caso a variável não seja definida, o valor padrão `/api` será utilizado.

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,6 +1,6 @@
 
-// A URL base da nossa API backend
-const API_BASE_URL = '/api';
+// A URL base da nossa API backend pode ser configurada via variável de ambiente
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 /**
  * Função genérica para fazer requisições à API.


### PR DESCRIPTION
## Summary
- allow configuring API base URL via environment variable
- document how to set API base URL in different environments

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7e4313188832689b2a8152810ca8a