### PR TITLE
Replace TinyMCE with simple built-in editor

### DIFF
--- a/editor.css
+++ b/editor.css
@@ -9,6 +9,27 @@
 
 .editor-card .card-body {
     flex-grow: 1;
-    display: flex; /* Garante que o container do editor também cresça */
+    display: flex;
+    flex-direction: column;
     padding: 0; /* O editor já tem suas próprias margens */
 }
+
+.toolbar {
+    border-bottom: 1px solid #ccc;
+    padding: 0.5rem;
+}
+
+.toolbar button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    margin-right: 0.5rem;
+    font-size: 1rem;
+}
+
+#editor-de-texto {
+    flex-grow: 1;
+    padding: 1rem;
+    outline: none;
+}
+

--- a/editor.html
+++ b/editor.html
@@ -4,20 +4,16 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SDI - Editor de Documento</title>
-    
+
     <link rel="stylesheet" href="dashboard.css">
-    <link rel="stylesheet" href="editor.css"> <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
-    <script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/6/tinymce.min.js" referrerpolicy="origin"></script>
+    <link rel="stylesheet" href="editor.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 </head>
 <body>
-
     <div class="dashboard-container">
-        
-        <aside class="sidebar">
-            </aside>
+        <aside class="sidebar"></aside>
 
         <main class="main-content">
-            
             <header class="main-header">
                 <div class="page-title">
                     <h2>Editor de Documento</h2>
@@ -32,15 +28,23 @@
 
             <section class="module-card editor-card">
                 <div class="card-body">
-                    <textarea id="editor-de-texto">
+                    <div class="toolbar">
+                        <button type="button" data-command="bold"><i class="fa-solid fa-bold"></i></button>
+                        <button type="button" data-command="italic"><i class="fa-solid fa-italic"></i></button>
+                        <button type="button" data-command="underline"><i class="fa-solid fa-underline"></i></button>
+                        <button type="button" data-command="insertUnorderedList"><i class="fa-solid fa-list-ul"></i></button>
+                        <button type="button" data-command="insertOrderedList"><i class="fa-solid fa-list-ol"></i></button>
+                    </div>
+                    <div id="editor-de-texto" contenteditable="true">
                         <p>Prezado(a) Senhor(a),</p>
                         <p>Este é um exemplo de conteúdo inicial para o documento que está sendo criado no editor.</p>
                         <p>Atenciosamente,</p>
-                    </textarea>
+                    </div>
                 </div>
             </section>
         </main>
     </div>
 
-    <script src="editor.js"></script> </body>
+    <script src="editor.js"></script>
+</body>
 </html>

--- a/editor.js
+++ b/editor.js
@@ -1,11 +1,8 @@
-document.addEventListener('DOMContentLoaded', function() {
-    
-    tinymce.init({
-        selector: '#editor-de-texto',
-        height: '100%', // Ocupa a altura do container
-        menubar: false,
-        plugins: 'advlist autolink lists link image charmap print preview anchor searchreplace visualblocks code fullscreen insertdatetime media table paste code help wordcount',
-        toolbar: 'undo redo | formatselect | bold italic backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | removeformat | help'
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.toolbar button').forEach((button) => {
+        button.addEventListener('click', () => {
+            const command = button.dataset.command;
+            document.execCommand(command, false, null);
+        });
     });
-
 });


### PR DESCRIPTION
## Summary
- replace TinyMCE-based editor with a lightweight contenteditable implementation
- add formatting toolbar and JS handlers for basic commands
- style toolbar and editor area for better usability

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test` (frontend) *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c7defb7b248326a8516e83469703cc