### PR TITLE
docs: add env example and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,11 @@ GRANT ALL PRIVILEGES ON DATABASE sdi_db TO postgres;
 cd backend
 npm install
 cp .env.example .env
-# Preencha o arquivo .env com os valores reais
+# Edite o arquivo .env com os valores do seu ambiente:
+# DB_USER, DB_PASSWORD, DB_HOST, DB_DATABASE, DB_PORT, PORT
 ```
 
-Em seguida, edite o arquivo `.env` preenchendo as credenciais e configurações do seu ambiente.
+O arquivo `.env.example` lista as variáveis necessárias; copie-o para `.env` e preencha os valores conforme seu ambiente.
 
 ### 5. Execute o script de criação do banco
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,4 @@
+# Exemplo de configuração de variáveis de ambiente
 DB_USER=postgres
 DB_PASSWORD=changeme
 DB_HOST=localhost


### PR DESCRIPTION
## Summary
- document backend env vars and provide example file
- guide users to copy `.env.example` to `.env`

## Testing
- `cd backend && npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f402b2c48326b868fa36dc0c498b