### PR TITLE
Document Vite env variables and API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ O servidor estará rodando em `http://localhost:3000`
 
 Abra o arquivo `dashboard.html` em seu navegador ou configure um servidor web local para servir os arquivos HTML.
 
+## Variáveis de ambiente do frontend
+
+O frontend React usa Vite, que expõe apenas variáveis prefixadas com `VITE_` ao código do navegador. Defina-as no arquivo `frontend/.env`.
+
+```env
+VITE_API_BASE_URL=/api
+```
+
+No código, acesse com `import.meta.env.VITE_API_BASE_URL`.
+
 ## 📁 Estrutura do Projeto
 
 ```

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,2 @@
+# Base URL for API requests
 VITE_API_BASE_URL=/api

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,6 +1,9 @@
-
-// A URL base da nossa API backend pode ser configurada via variável de ambiente
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
+/**
+ * Base URL for API requests.
+ * Configurable via the VITE_API_BASE_URL environment variable.
+ * Defaults to '/api'.
+ */
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 /**
  * Função genérica para fazer requisições à API.


### PR DESCRIPTION
## Summary
- configure API base URL via `VITE_API_BASE_URL`
- expose `API_BASE_URL` from frontend API helper
- document `VITE_*` variables in README

## Testing
- `npm test` (frontend) *(fails: vitest not found)*
- `npm test` (backend) *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f40ae1a88326bb5afcecc500f5c3