### PR TITLE
Add basic test scaffolding for backend and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,12 +191,16 @@ npm run db:setup
 
 ### Backend
 
+Os testes do backend são escritos com **Jest** e **Supertest**.
+
 ```bash
 cd backend
 npm test
 ```
 
 ### Frontend
+
+Os testes do frontend utilizam **Vitest** e **@testing-library/react**.
 
 ```bash
 cd frontend

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,9 +18,9 @@
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
     "pg": "^8.16.3",
-    "winston": "^3.10.0"
+    "winston": "^3.10.0",
     "jsonwebtoken": "^9.0.2",
-    "bcrypt": "^5.1.1"
+    "bcrypt": "^5.1.1",
     "express-validator": "^6.14.3"
   },
   "devDependencies": {
@@ -29,3 +29,4 @@
     "supertest": "^6.3.4"
   }
 }
+

--- a/backend/server.js
+++ b/backend/server.js
@@ -37,15 +37,6 @@ app.get('/', (req, res) => {
     res.send('API do SDI está no ar!');
 });
 
-// 7. Iniciar o servidor
-if (require.main === module) {
-    app.listen(PORT, () => {
-        console.log(`Servidor rodando com sucesso na porta ${PORT}`);
-    });
-}
-
-module.exports = app;
-
 // 7. Middleware para rota não encontrada
 app.use((req, res) => res.status(404).json({ error: 'Rota não encontrada' }));
 
@@ -56,9 +47,10 @@ app.use((err, req, res, next) => {
 });
 
 // 9. Iniciar o servidor
-app.listen(PORT, () => {
-    logger.info(`Servidor rodando com sucesso na porta ${PORT}`);
-});
+if (require.main === module) {
+    app.listen(PORT, () => {
+        logger.info(`Servidor rodando com sucesso na porta ${PORT}`);
+    });
+}
 
-    console.log(`Servidor rodando com sucesso na porta ${PORT}`);
-});
+module.exports = app;

--- a/backend/tests/math.test.js
+++ b/backend/tests/math.test.js
@@ -1,0 +1,7 @@
+const sum = (a, b) => a + b;
+
+describe('sum', () => {
+  it('adds two numbers', () => {
+    expect(sum(1, 1)).toBe(2);
+  });
+});

--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import App from '../App.jsx';
+import { vi } from 'vitest';
+
+vi.mock('../api', () => ({
+  api: {
+    processos: {
+      getAll: vi.fn().mockResolvedValue({ data: [], total: 0 })
+    }
+  }
+}));
+
+describe('App', () => {
+  it('renders dashboard heading', async () => {
+    render(<App />);
+    expect(await screen.findByText(/Recebidos/i)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- fix backend `package.json` and `server.js` to support testing
- add sample Jest/Supertest test and Vitest React test
- document how to run backend and frontend tests

## Testing
- `cd backend && npm test` *(fails: jest not found)*
- `cd frontend && npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f4015e208326b4e148c72178f470